### PR TITLE
Fix: Temporary avoid conflicts

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -26,6 +26,6 @@
         "description": "插件黑名单",
         "hint": "填写插件名称(区分大小写)，如：astrbot_plugin_help，黑名单中的插件不会参与命令发现与调用",
         "type": "list",
-        "default": []
+        "default": [astrbot_plugin_Heartflow, astrbot_plugin_debounce]
     }
 }

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -26,6 +26,6 @@
         "description": "插件黑名单",
         "hint": "填写插件名称(区分大小写)，如：astrbot_plugin_help，黑名单中的插件不会参与命令发现与调用",
         "type": "list",
-        "default": [astrbot_plugin_Heartflow, astrbot_plugin_debounce]
+        "default": ["astrbot_plugin_Heartflow", "astrbot_plugin_debounce"]
     }
 }


### PR DESCRIPTION
重置对话时会和Heartflow产生循环

<img width="800" height="1280" alt="Image" src="https://github.com/user-attachments/assets/432d00d9-6257-47f4-8597-66fea700bb93" />

旁路忽略会对消息防抖产生误判导致最后什么也不输出

<img width="800" height="1280" alt="Image" src="https://github.com/user-attachments/assets/2be11ae4-ac1c-4f60-811a-133453f650ad" />

所有版本都是当前最新，为了找这两个冲突熬穿了。暂时增加默认黑名单，希望尽快修复。

## Summary by Sourcery

Enhancements:
- Adjust configuration schema related to message debouncing and bypass handling to reduce misclassification and avoid empty output.